### PR TITLE
#93: fix bug where sem analysis was not enforcing return statements for non-void functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,6 @@ cmake_install.cmake
 compile_commands.json
 
 # Examples folder
+/examples
 examples/*.cpp
 examples/*.qasm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ This project follows [Semantic Versioning](https://semver.org/) and the [Keep a 
 - #87: fix bug where `echo()` was printing to the console twice
 - #78: fix bug where looped measurements of the same qubit were overwriting old measurements
 - #94: `echo()` now works with all and mixed data types
+- #93: ensure semantic analysis enforces non-void functions to end with a return statement
 
 ### Removed  
 - #24: remove old `version` starter code

--- a/src/bloch/semantics/semantic_analyser.cpp
+++ b/src/bloch/semantics/semantic_analyser.cpp
@@ -47,6 +47,7 @@ namespace bloch {
     }
 
     void SemanticAnalyser::visit(ReturnStatement& node) {
+        m_foundReturn = true;
         bool isVoid = m_currentReturnType == ValueType::Void;
         if (node.value && isVoid) {
             throw BlochRuntimeError("Bloch Semantic Error", node.line, node.column,
@@ -297,6 +298,8 @@ namespace bloch {
         }
         m_functionInfo[node.name] = info;
 
+        bool prevFoundReturn = m_foundReturn;
+        m_foundReturn = false;
         beginScope();
         for (auto& param : node.params) {
             if (isDeclared(param->name)) {
@@ -313,8 +316,12 @@ namespace bloch {
         }
         if (node.body)
             node.body->accept(*this);
+        if (m_currentReturnType != ValueType::Void && !m_foundReturn) {
+            throw BlochRuntimeError("Bloch Semantic Error", node.line, node.column, "Non-void function must have a 'return' statement.");
+        }
         endScope();
-
+        
+        m_foundReturn = prevFoundReturn;
         m_currentReturnType = prevReturn;
     }
 

--- a/src/bloch/semantics/semantic_analyser.cpp
+++ b/src/bloch/semantics/semantic_analyser.cpp
@@ -317,10 +317,11 @@ namespace bloch {
         if (node.body)
             node.body->accept(*this);
         if (m_currentReturnType != ValueType::Void && !m_foundReturn) {
-            throw BlochRuntimeError("Bloch Semantic Error", node.line, node.column, "Non-void function must have a 'return' statement.");
+            throw BlochRuntimeError("Bloch Semantic Error", node.line, node.column,
+                                    "Non-void function must have a 'return' statement.");
         }
         endScope();
-        
+
         m_foundReturn = prevFoundReturn;
         m_currentReturnType = prevReturn;
     }

--- a/src/bloch/semantics/semantic_analyser.hpp
+++ b/src/bloch/semantics/semantic_analyser.hpp
@@ -52,6 +52,7 @@ namespace bloch {
        private:
         SymbolTable m_symbols;
         ValueType m_currentReturnType = ValueType::Unknown;
+        bool m_foundReturn = false;
         std::unordered_set<std::string> m_functions;
 
         struct FunctionInfo {

--- a/tests/test_semantics.cpp
+++ b/tests/test_semantics.cpp
@@ -119,6 +119,13 @@ TEST(SemanticTest, NonVoidFunctionNeedsValue) {
     EXPECT_THROW(analyser.analyse(*program), BlochRuntimeError);
 }
 
+TEST(SemanticTest, NonVoidFunctionMissingReturnFails) {
+    const char* src = "function foo() -> int { int x = 1; }";
+    auto program = parseProgram(src);
+    SemanticAnalyser analyser;
+    EXPECT_THROW(analyser.analyse(*program), BlochRuntimeError);
+}
+
 TEST(SemanticTest, FinalVariableAssignmentFails) {
     const char* src = "final int x = 1; x = 2;";
     auto program = parseProgram(src);


### PR DESCRIPTION
Semantic Analysis now enforces non-void functions to have a `return` statement. 

closes #93 