### PR TITLE
#101: allow inline multiple variable declaration for qubits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This project follows [Semantic Versioning](https://semver.org/) and the [Keep a 
 - #32: added `while` keyword
 - #29: added ternary operator
 - #55: added post increment and decrement operators `++` and `--`
+- #101: added inline multiple variable declaration for `qubit`
 
 ### Changed
 - #3: prefix private class members with `m_`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,10 +43,16 @@ git checkout -b feature/02
 git commit -m "#15: fix bug" 
 ```
 
-### 6. Push and Create a Pull Request
+### 6. Add to the CHANGELOG
+- Add an entry to `CHANGELOG.md` describing your change and referencing the issue number eg
+```md
+#100 - Added 100 new `.bloch` code examples
+```
+
+### 7. Push and Create a Pull Request
 - Once you've done this please move the issue to the "In Review" column on the project board
 
-### 7. PR Reviews
+### 8. PR Reviews
 - We’ll review your PR as quickly as possible.
 - Please be open to feedback and changes.
 

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -30,7 +30,8 @@ statement      = block
 
 forInit        = ( "final" )? variableDeclaration | expressionStatement ;
 
-variableDeclaration = annotations? type identifier [ "=" expression ] ";" ;
+variableDeclaration = annotations? type identifier { "," identifier } [ "=" expression ] ";" ;
+
 annotations    = annotation { annotation } ;
 
 assignment     = identifier "=" expression ";" ;

--- a/src/bloch/parser/parser.hpp
+++ b/src/bloch/parser/parser.hpp
@@ -16,6 +16,7 @@ namespace bloch {
        private:
         std::vector<Token> m_tokens;
         size_t m_current;
+        std::vector<std::unique_ptr<Statement>> m_extraStatements;
 
         // Token manipulation
         [[nodiscard]] const Token& peek() const;
@@ -37,9 +38,10 @@ namespace bloch {
         [[nodiscard]] std::unique_ptr<FunctionDeclaration> parseFunction();
 
         // Declarations
-        [[nodiscard]] std::unique_ptr<VariableDeclaration> parseVariableDeclaration(bool isFinal);
         [[nodiscard]] std::unique_ptr<VariableDeclaration> parseVariableDeclaration(
-            std::unique_ptr<Type> preParsedType, bool isFinal);
+            bool isFinal, bool allowMultiple = true);
+        [[nodiscard]] std::unique_ptr<VariableDeclaration> parseVariableDeclaration(
+            std::unique_ptr<Type> preParsedType, bool isFinal, bool allowMultiple = true);
         [[nodiscard]] std::unique_ptr<AnnotationNode> parseAnnotation();
         [[nodiscard]] std::vector<std::unique_ptr<AnnotationNode>> parseAnnotations();
 
@@ -78,5 +80,11 @@ namespace bloch {
         // Parameters and Arguments
         [[nodiscard]] std::vector<std::unique_ptr<Parameter>> parseParameterList();
         [[nodiscard]] std::vector<std::unique_ptr<Expression>> parseArgumentList();
+
+        // Helpers
+        [[nodiscard]] std::unique_ptr<Type> cloneType(const Type& type);
+        [[nodiscard]] std::vector<std::unique_ptr<AnnotationNode>> cloneAnnotations(
+            const std::vector<std::unique_ptr<AnnotationNode>>& annotations);
+        void flushExtraStatements(std::vector<std::unique_ptr<Statement>>& dest);
     };
 }

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -124,7 +124,6 @@ TEST(ParserTest, RejectMultipleNonQubitDeclarations) {
     EXPECT_THROW((void)parser.parse(), BlochRuntimeError);
 }
 
-
 TEST(ParserTest, ParseClassicalFunction) {
     const char* src = "function add(int a, int b) -> int { return a + b; }";
     Lexer lexer(src);

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -102,6 +102,29 @@ TEST(ParserTest, StateAnnotationIsRejected) {
     EXPECT_THROW((void)parser.parse(), BlochRuntimeError);
 }
 
+TEST(ParserTest, ParseMultipleQubitDeclarations) {
+    Lexer lexer("qubit q, r;");
+    auto tokens = lexer.tokenize();
+    Parser parser(std::move(tokens));
+    auto program = parser.parse();
+
+    ASSERT_EQ(program->statements.size(), 2u);
+    auto* q = dynamic_cast<VariableDeclaration*>(program->statements[0].get());
+    auto* r = dynamic_cast<VariableDeclaration*>(program->statements[1].get());
+    ASSERT_NE(q, nullptr);
+    ASSERT_NE(r, nullptr);
+    EXPECT_EQ(q->name, "q");
+    EXPECT_EQ(r->name, "r");
+}
+
+TEST(ParserTest, RejectMultipleNonQubitDeclarations) {
+    Lexer lexer("int a, b;");
+    auto tokens = lexer.tokenize();
+    Parser parser(std::move(tokens));
+    EXPECT_THROW((void)parser.parse(), BlochRuntimeError);
+}
+
+
 TEST(ParserTest, ParseClassicalFunction) {
     const char* src = "function add(int a, int b) -> int { return a + b; }";
     Lexer lexer(src);

--- a/tests/test_runtime.cpp
+++ b/tests/test_runtime.cpp
@@ -41,7 +41,6 @@ TEST(RuntimeTest, MultipleQubitDeclarationsAllocateDistinctQubits) {
     EXPECT_NE(qasm.find("h q[1]"), std::string::npos);
 }
 
-
 TEST(RuntimeTest, MeasurementsPreservedInForLoops) {
     const char* src =
         "@quantum function flip() -> bit { qubit q; x(q); bit r = measure q; return r; } "

--- a/tests/test_runtime.cpp
+++ b/tests/test_runtime.cpp
@@ -29,6 +29,19 @@ TEST(RuntimeTest, GeneratesQasm) {
     EXPECT_NE(qasm.find("measure q[0]"), std::string::npos);
 }
 
+TEST(RuntimeTest, MultipleQubitDeclarationsAllocateDistinctQubits) {
+    const char* src = "function main() -> void { qubit q0, q1; h(q0); h(q1); }";
+    auto program = parseProgram(src);
+    SemanticAnalyser analyser;
+    analyser.analyse(*program);
+    RuntimeEvaluator eval;
+    eval.execute(*program);
+    std::string qasm = eval.getQasm();
+    EXPECT_NE(qasm.find("h q[0]"), std::string::npos);
+    EXPECT_NE(qasm.find("h q[1]"), std::string::npos);
+}
+
+
 TEST(RuntimeTest, MeasurementsPreservedInForLoops) {
     const char* src =
         "@quantum function flip() -> bit { qubit q; x(q); bit r = measure q; return r; } "


### PR DESCRIPTION
Allow inline multuple variable declaration for qubits eg
```bloch
qubit q, r; 
```