### PR TITLE
#112: removed @adjoint annotation as not MVP

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -8,7 +8,7 @@ import         = "import" identifier ";" ;
 function       = { annotation } "function" identifier
                   "(" [ parameterList ] ")" "->" type block ;
 
-annotation     = "@" ( "quantum" | "adjoint" ) ;
+annotation     = "@" "quantum" ;
 
 parameterList  = parameter { "," parameter } ;
 parameter      = type identifier ;

--- a/examples/tracked.bloch
+++ b/examples/tracked.bloch
@@ -1,4 +1,5 @@
 @quantum
+@adjoint
 function measure_hadamard(qubit q) -> bit {
     h(q);
     return measure q;

--- a/src/bloch/lexer/lexer.cpp
+++ b/src/bloch/lexer/lexer.cpp
@@ -213,7 +213,6 @@ namespace bloch {
 
             // Annotation Values
             {"quantum", TokenType::Quantum},
-            {"adjoint", TokenType::Adjoint},
             {"tracked", TokenType::Tracked},
 
             // Built ins

--- a/src/bloch/lexer/token.hpp
+++ b/src/bloch/lexer/token.hpp
@@ -33,7 +33,6 @@ namespace bloch {
         // Annotations
         At,
         Quantum,
-        Adjoint,
         Tracked,
 
         // Operators and Punctuation

--- a/src/bloch/parser/parser.cpp
+++ b/src/bloch/parser/parser.cpp
@@ -94,7 +94,8 @@ namespace bloch {
             } else {
                 const Token& invalid = peek();
                 std::string invalidName = invalid.value.empty() ? std::string("") : invalid.value;
-                reportError(std::string("\"") + "@" + invalidName + "\" is not a valid Bloch annotation");
+                reportError(std::string("\"") + "@" + invalidName +
+                            "\" is not a valid Bloch annotation");
             }
         }
 
@@ -209,11 +210,11 @@ namespace bloch {
     std::unique_ptr<AnnotationNode> Parser::parseAnnotation() {
         (void)expect(TokenType::At, "Expected '@' to begin annotation");
 
-        if (!check(TokenType::Quantum) &&
-            !check(TokenType::Tracked)) {
+        if (!check(TokenType::Quantum) && !check(TokenType::Tracked)) {
             const Token& invalid = peek();
             std::string invalidName = invalid.value.empty() ? std::string("") : invalid.value;
-            reportError(std::string("\"") + "@" + invalidName + "\" is not a valid Bloch annotation");
+            reportError(std::string("\"") + "@" + invalidName +
+                        "\" is not a valid Bloch annotation");
         }
         auto nameToken = advance();
         auto annotation = std::make_unique<AnnotationNode>();

--- a/src/bloch/parser/parser.cpp
+++ b/src/bloch/parser/parser.cpp
@@ -47,7 +47,7 @@ namespace bloch {
     bool Parser::checkFunctionAnnotation() const {
         if (!check(TokenType::At))
             return false;
-        if (!checkNext(TokenType::Quantum) && !checkNext(TokenType::Adjoint))
+        if (!checkNext(TokenType::Quantum))
             return false;
         return true;
     }
@@ -85,14 +85,16 @@ namespace bloch {
         // Parse annotations
         while (check(TokenType::At)) {
             (void)advance();
-            if (match(TokenType::Quantum) || match(TokenType::Adjoint)) {
+            if (match(TokenType::Quantum)) {
                 std::string name = previous().value;
                 std::string value = "";
                 func->annotations.push_back(
                     std::make_unique<AnnotationNode>(AnnotationNode{name, value}));
                 func->hasQuantumAnnotation = true;
             } else {
-                reportError("Expected annotation name after '@'");
+                const Token& invalid = peek();
+                std::string invalidName = invalid.value.empty() ? std::string("") : invalid.value;
+                reportError(std::string("\"") + "@" + invalidName + "\" is not a valid Bloch annotation");
             }
         }
 
@@ -203,13 +205,15 @@ namespace bloch {
         return var;
     }
 
-    // @quantum, @adjoint, @tracked
+    // @quantum, @tracked
     std::unique_ptr<AnnotationNode> Parser::parseAnnotation() {
         (void)expect(TokenType::At, "Expected '@' to begin annotation");
 
-        if (!check(TokenType::Quantum) && !check(TokenType::Adjoint) &&
+        if (!check(TokenType::Quantum) &&
             !check(TokenType::Tracked)) {
-            reportError("Unknown annotation");
+            const Token& invalid = peek();
+            std::string invalidName = invalid.value.empty() ? std::string("") : invalid.value;
+            reportError(std::string("\"") + "@" + invalidName + "\" is not a valid Bloch annotation");
         }
         auto nameToken = advance();
         auto annotation = std::make_unique<AnnotationNode>();

--- a/src/bloch/runtime/runtime_evaluator.cpp
+++ b/src/bloch/runtime/runtime_evaluator.cpp
@@ -158,7 +158,7 @@ namespace bloch {
             Value v = eval(echo->value.get());
             if (m_echoEnabled)
                 std::cout << valueToString(v) << std::endl;
-        } else if (auto reset = dynamic_cast<ResetStatement*>(s)) {
+        } else if (dynamic_cast<ResetStatement*>(s)) {
             // ignore
         } else if (auto meas = dynamic_cast<MeasureStatement*>(s)) {
             Value q = eval(meas->qubit.get());

--- a/src/bloch/runtime/runtime_evaluator.hpp
+++ b/src/bloch/runtime/runtime_evaluator.hpp
@@ -16,7 +16,7 @@ namespace bloch {
         int intValue = 0;
         double floatValue = 0.0;
         int bitValue = 0;
-        std::string stringValue;
+        std::string stringValue = "";
         int qubit = -1;
     };
 


### PR DESCRIPTION
Removed the `@adjoint` annotation as not MVP and more design consideration is required for it's implementation, likely v1.3.0. Also refactored annotation parser error messages