### PR TITLE
#76: fix `reset` operation in simulator and runtime

### DIFF
--- a/examples/reset.bloch
+++ b/examples/reset.bloch
@@ -1,0 +1,13 @@
+@quantum 
+function try_reset() -> bit { 
+    qubit q; 
+    x(q); 
+    reset q; 
+    bit r = measure q; 
+    return r; 
+}
+
+function main() -> void {
+    @tracked bit b = 0b;
+    b = try_reset();
+}

--- a/src/bloch/runtime/qasm_simulator.cpp
+++ b/src/bloch/runtime/qasm_simulator.cpp
@@ -97,6 +97,22 @@ namespace bloch {
         m_ops += "cx q[" + std::to_string(control) + "],q[" + std::to_string(target) + "];\n";
     }
 
+    void QasmSimulator::reset(int q) {
+        size_t bit = size_t{1} << q;
+        double norm = 0.0;
+        for (size_t i = 0; i < m_state.size(); ++i) {
+            if (!(i & bit))
+                norm += std::norm(m_state[i]);
+            else
+                m_state[i] = 0;
+        }
+        norm = std::sqrt(norm);
+        for (size_t i = 0; i < m_state.size(); ++i)
+            if (!(i & bit))
+                m_state[i] /= norm;
+        m_ops += "reset q[" + std::to_string(q) + "];\n";
+    }
+
     int QasmSimulator::measure(int q) {
         size_t bit = size_t{1} << q;
         double p1 = 0;

--- a/src/bloch/runtime/qasm_simulator.hpp
+++ b/src/bloch/runtime/qasm_simulator.hpp
@@ -18,6 +18,7 @@ namespace bloch {
         void ry(int q, double theta);
         void rz(int q, double theta);
         void cx(int control, int target);
+        void reset(int q);
         int measure(int q);
         std::string getQasm() const;
 

--- a/src/bloch/runtime/runtime_evaluator.hpp
+++ b/src/bloch/runtime/runtime_evaluator.hpp
@@ -59,6 +59,7 @@ namespace bloch {
         void assign(const std::string& name, const Value& v);
         int allocateTrackedQubit(const std::string& name);
         void markMeasured(int index);
+        void unmarkMeasured(int index);
         void warnUnmeasured() const;
         void beginScope();
         void endScope();

--- a/tests/test_runtime.cpp
+++ b/tests/test_runtime.cpp
@@ -172,3 +172,16 @@ TEST(RuntimeTest, UninitializedTrackedVariable) {
     const auto& counts = eval.trackedCounts();
     ASSERT_EQ(counts.at("x").at("__unassigned__"), 1);
 }
+
+TEST(RuntimeTest, ResetClearsQubit) {
+    const char* src =
+        "@quantum function main() -> bit { qubit q; x(q); reset q; bit r = measure q; return r; }";
+    auto program = parseProgram(src);
+    SemanticAnalyser analyser;
+    analyser.analyse(*program);
+    RuntimeEvaluator eval;
+    eval.execute(*program);
+    const auto& meas = eval.measurements();
+    ASSERT_EQ(meas.size(), 1u);
+    EXPECT_EQ(meas.begin()->second[0], 0);
+}


### PR DESCRIPTION
Fix the `reset` operation in the simulator and runtime which was previously unimplemented. 