### PR TITLE
#123: refactor `@tracked` CLI output

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -31,7 +31,7 @@ jobs:
               | xargs -0 -r "$CLANG_FORMAT" -style=file -n --Werror; then
               echo ""
               echo "❌ Code is not formatted correctly."
-              echo "👉 Please run: $CLANG_FORMAT -i \$(find . -regex '.*\.\(cpp\|hpp\|c\|h\)')"
+              echo "👉 Please run: clang-format-14 -i \$(find . -regex '.*\.\(cpp\|hpp\|c\|h\)')"
               echo ""
               exit 1
             else

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -15,18 +15,23 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake g++ clang-format
+          sudo apt-get install -y cmake g++ clang-format-14
 
       - name: Check formatting
         run: |
+          set -euo pipefail
+          CLANG_FORMAT=clang-format-14
+          "$CLANG_FORMAT" --version
+          # Use -print0 + xargs -0 to handle spaces and large file sets
           FILES=$(find . -regex '.*\.\(cpp\|hpp\|c\|h\)')
           if [ -n "$FILES" ]; then
             echo "Checking formatting for files:"
             echo "$FILES"
-            if ! clang-format --dry-run --Werror $FILES; then
+            if ! find . -regex '.*\.\(cpp\|hpp\|c\|h\)' -print0 \
+              | xargs -0 -r "$CLANG_FORMAT" -style=file -n --Werror; then
               echo ""
               echo "❌ Code is not formatted correctly."
-              echo "👉 Please run: clang-format -i \$(find . -regex '.*\.\(cpp\|hpp\|c\|h\)')"
+              echo "👉 Please run: $CLANG_FORMAT -i \$(find . -regex '.*\.\(cpp\|hpp\|c\|h\)')"
               echo ""
               exit 1
             else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ This project follows [Semantic Versioning](https://semver.org/) and the [Keep a 
 - #77: simplifed Parser by making better use of the `expect` function
 - #107: require `b` suffix for `bit` literals to disambiguate from `int`
 - #116: refactored error reporting for better user experience
+- #123: refactored `@tracked` rules and CLI output
 
 ### Fixed
 - #11: minor readme bugfixes

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,4 +2,5 @@
 
 This folder contains example programs written in **Bloch**, showcasing key language features and patterns for building quantum–classical workflows. Each example is designed to be runnable with the Bloch CLI and serves as both a tutorial and a testbed for the language.
 
-- **superposition.bloch** – demonstrates integration of quantum and classical flows. Defines an `@quantum` function that prepares a qubit in superposition and measures it. The result is sampled in a loop, counts of 0s and 1s are tracked, and the totals are printed.
+- **superposition.bloch** – demonstrates integration of quantum and classical flows. Defines an `@quantum` function that prepares a qubit in superposition and measures it. The result is sampled in a loop and the totals are printed.
+- **entangled_tracked.bloch** – tracks a `qubit[]` register prepared in a Bell state (H + CX) and measures both qubits to produce outcome counts like `00` and `11`.

--- a/examples/entangled_tracked.bloch
+++ b/examples/entangled_tracked.bloch
@@ -1,0 +1,19 @@
+@quantum
+function logic(qubit[] qreg) -> void {
+    h(qreg[0]);
+    cx(qreg[0], qreg[1]);
+}
+
+
+function main() -> void {
+    // Track a 2-qubit register prepared in a Bell state.
+    @tracked qubit[2] qreg;
+
+    // Apply logic
+    logic(qreg);
+    
+    // Explicitly measure to populate outcomes like 00/11
+    measure qreg[0];
+    measure qreg[1];
+}
+

--- a/examples/reset.bloch
+++ b/examples/reset.bloch
@@ -8,6 +8,5 @@ function try_reset() -> bit {
 }
 
 function main() -> void {
-    @tracked bit b = 0b;
-    b = try_reset();
+    bit b = try_reset();
 }

--- a/examples/superposition.bloch
+++ b/examples/superposition.bloch
@@ -7,9 +7,10 @@ function superposition() -> bit {
 
 function main() -> void {
     int i = 0;
-    @tracked int ones = 0;
-    @tracked int zeros = 0;
-    while (i < 10) {
+    int N = 10;
+    int ones = 0;
+    int zeros = 0;
+    while (i < N) {
         bit b = superposition();
         if (b == 1b) {
             ones++;
@@ -18,6 +19,8 @@ function main() -> void {
         }
         i = i + 1;
     }
-echo("0s measured: " + zeros);
-echo("1s measured: " + ones);
+int zero_prob = zeros/N;
+int one_prob = ones/N;
+echo("0s " + zeros + ", " + zero_prob);
+echo("1s " + ones + ", " + one_prob);
 }

--- a/examples/tracked.bloch
+++ b/examples/tracked.bloch
@@ -5,8 +5,7 @@ function measure_hadamard(qubit q) -> bit {
 }
 
 function main() -> void {
-    qubit q;
-    
-    @tracked bit b = measure_hadamard(q);
+    @tracked qubit q;
+    bit b = measure_hadamard(q);
     echo(b);
 }

--- a/src/bloch/ast/ast.hpp
+++ b/src/bloch/ast/ast.hpp
@@ -10,7 +10,7 @@ namespace bloch {
     // its source position and supports a classic visitor for later stages
     // (semantic analysis and execution).
     // Only the essentials live here to keep traversal cheap and predictable.
-    
+
     // Base Node Interfaces
     class ASTVisitor;
 

--- a/src/bloch/runtime/runtime_evaluator.cpp
+++ b/src/bloch/runtime/runtime_evaluator.cpp
@@ -948,8 +948,7 @@ namespace bloch {
                 if (!allMeasured) {
                     outcome = "?";
                 } else {
-                    for (int q : v.qubitArray)
-                        bits.push_back(m_lastMeasurement[q] ? '1' : '0');
+                    for (int q : v.qubitArray) bits.push_back(m_lastMeasurement[q] ? '1' : '0');
                     outcome = bits;
                 }
                 std::string key = std::string("qubit[] ") + name;

--- a/src/bloch/runtime/runtime_evaluator.cpp
+++ b/src/bloch/runtime/runtime_evaluator.cpp
@@ -351,8 +351,10 @@ namespace bloch {
             unmarkMeasured(q.qubit);
         } else if (auto meas = dynamic_cast<MeasureStatement*>(s)) {
             Value q = eval(meas->qubit.get());
-            m_sim.measure(q.qubit);
+            int bit = m_sim.measure(q.qubit);
             markMeasured(q.qubit);
+            if (q.qubit >= 0 && q.qubit < static_cast<int>(m_lastMeasurement.size()))
+                m_lastMeasurement[q.qubit] = bit;
         } else if (auto assignStmt = dynamic_cast<AssignmentStatement*>(s)) {
             Value val = eval(assignStmt->value.get());
             assign(assignStmt->name, val);
@@ -736,6 +738,8 @@ namespace bloch {
             Value q = eval(idx->qubit.get());
             int bit = m_sim.measure(q.qubit);
             markMeasured(q.qubit);
+            if (q.qubit >= 0 && q.qubit < static_cast<int>(m_lastMeasurement.size()))
+                m_lastMeasurement[q.qubit] = bit;
             m_measurements[e].push_back(bit);
             return {Value::Type::Bit, 0, 0.0, bit};
         } else if (auto indexExpr = dynamic_cast<IndexExpression*>(e)) {
@@ -883,6 +887,8 @@ namespace bloch {
     int RuntimeEvaluator::allocateTrackedQubit(const std::string& name) {
         int idx = m_sim.allocateQubit();
         m_qubits.push_back({name, false});
+        if (idx >= static_cast<int>(m_lastMeasurement.size()))
+            m_lastMeasurement.resize(idx + 1, -1);
         return idx;
     }
 
@@ -894,6 +900,8 @@ namespace bloch {
     void RuntimeEvaluator::unmarkMeasured(int index) {
         if (index >= 0 && index < static_cast<int>(m_qubits.size()))
             m_qubits[index].measured = false;
+        if (index >= 0 && index < static_cast<int>(m_lastMeasurement.size()))
+            m_lastMeasurement[index] = -1;
     }
 
     void RuntimeEvaluator::warnUnmeasured() const {
@@ -912,10 +920,40 @@ namespace bloch {
         if (m_env.empty())
             return;
         for (auto& kv : m_env.back()) {
-            if (kv.second.tracked) {
-                std::string key =
-                    kv.second.initialized ? valueToString(kv.second.value) : "__unassigned__";
-                m_trackedCounts[kv.first][key]++;
+            if (!kv.second.tracked)
+                continue;
+            const auto& name = kv.first;
+            const auto& entry = kv.second;
+            const auto& v = entry.value;
+            if (v.type == Value::Type::Qubit) {
+                int q = v.qubit;
+                std::string outcome = "?";
+                if (q >= 0 && q < static_cast<int>(m_lastMeasurement.size()) &&
+                    m_lastMeasurement[q] != -1) {
+                    outcome = m_lastMeasurement[q] ? "1" : "0";
+                }
+                std::string key = std::string("qubit ") + name;
+                m_trackedCounts[key][outcome]++;
+            } else if (v.type == Value::Type::QubitArray) {
+                bool allMeasured = true;
+                std::string bits;
+                for (int q : v.qubitArray) {
+                    if (!(q >= 0 && q < static_cast<int>(m_lastMeasurement.size()) &&
+                          m_lastMeasurement[q] != -1)) {
+                        allMeasured = false;
+                        break;
+                    }
+                }
+                std::string outcome;
+                if (!allMeasured) {
+                    outcome = "?";
+                } else {
+                    for (int q : v.qubitArray)
+                        bits.push_back(m_lastMeasurement[q] ? '1' : '0');
+                    outcome = bits;
+                }
+                std::string key = std::string("qubit[] ") + name;
+                m_trackedCounts[key][outcome]++;
             }
         }
         m_env.pop_back();

--- a/src/bloch/runtime/runtime_evaluator.hpp
+++ b/src/bloch/runtime/runtime_evaluator.hpp
@@ -93,7 +93,7 @@ namespace bloch {
         void markMeasured(int index);
         void unmarkMeasured(int index);
         void warnUnmeasured() const;
-        
+
         // Scope & output helpers
         void beginScope();
         void endScope();

--- a/src/bloch/runtime/runtime_evaluator.hpp
+++ b/src/bloch/runtime/runtime_evaluator.hpp
@@ -78,6 +78,8 @@ namespace bloch {
             bool measured;
         };
         std::vector<QubitInfo> m_qubits;
+        // Last measured value per qubit index (-1 if never measured)
+        std::vector<int> m_lastMeasurement;
 
         // Core interpreter operations
         Value eval(Expression* expr);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,7 +25,7 @@ int main(int argc, char** argv) {
     //  --echo=all   echo statements are printed per shot
     //  --echo=none  no echo statements are printed
     // TODO: Add a --version and --help flag
-    // TODO: Add a --json flag 
+    // TODO: Add a --json flag
     bool emitQasm = false;
     int shots = 1;
     bool shotsProvided = false;
@@ -129,10 +129,12 @@ int main(int argc, char** argv) {
                     });
                     // Dynamic column sizing for outcome strings
                     size_t outcomeWidth = 7;
-                    for (const auto& p : vals) outcomeWidth = std::max(outcomeWidth, p.first.size());
+                    for (const auto& p : vals)
+                        outcomeWidth = std::max(outcomeWidth, p.first.size());
                     std::cout << std::left << std::setw(static_cast<int>(outcomeWidth)) << "outcome"
-                              << " | " << std::right << std::setw(5) << "count" << " | "
-                              << std::setw(5) << "prob" << "\n";
+                              << " | " << std::right << std::setw(5) << "count"
+                              << " | " << std::setw(5) << "prob"
+                              << "\n";
                     std::cout << std::string(outcomeWidth, '-') << "-+-------+-----\n";
                     for (auto& p : vals) {
                         double prob = static_cast<double>(p.second) / shots;

--- a/tests/test_integration.cpp
+++ b/tests/test_integration.cpp
@@ -117,33 +117,29 @@ function main() -> void {
 TEST(IntegrationTest, TrackedSingleShot) {
     std::string src = R"(
 function main() -> void {
-    @tracked int x = 1;
-    echo(x);
+    @tracked qubit q;
+    x(q);
 }
 )";
     std::string output = runBloch(src, "tracked_single.bloch", "--shots=1");
-    EXPECT_NE(output.find("1\nShots: 1"), std::string::npos);
-    EXPECT_NE(output.find("value | count | prob"), std::string::npos);
-    std::string compact = output;
-    compact.erase(std::remove(compact.begin(), compact.end(), ' '), compact.end());
-    EXPECT_NE(compact.find("1|1|1.000"), std::string::npos);
+    EXPECT_NE(output.find("Shots: 1"), std::string::npos);
+    EXPECT_NE(output.find("qubit q"), std::string::npos);
+    EXPECT_NE(output.find("?"), std::string::npos);
 }
 
 TEST(IntegrationTest, TrackedMultiShotAggregates) {
     std::string src = R"(
 function main() -> void {
-    @tracked int x = 1;
-    echo(x);
+    @tracked qubit q;
+    x(q);
 }
 )";
     std::string output = runBloch(src, "tracked_multi.bloch", "--shots=3");
     EXPECT_NE(output.find("[INFO]: suppressing echo; to view them use --echo=all"),
               std::string::npos);
     EXPECT_NE(output.find("Shots: 3"), std::string::npos);
-    EXPECT_NE(output.find("value | count | prob"), std::string::npos);
-    std::string compact2 = output;
-    compact2.erase(std::remove(compact2.begin(), compact2.end(), ' '), compact2.end());
-    EXPECT_NE(compact2.find("1|3|1.000"), std::string::npos);
+    EXPECT_NE(output.find("qubit q"), std::string::npos);
+    EXPECT_NE(output.find("?"), std::string::npos);
 }
 
 TEST(IntegrationTest, ArrayOperationsAndEcho) {

--- a/tests/test_runtime.cpp
+++ b/tests/test_runtime.cpp
@@ -162,7 +162,7 @@ TEST(RuntimeTest, EchoModes) {
     EXPECT_EQ("1\n", out.str());
 }
 
-TEST(RuntimeTest, UninitializedTrackedVariable) {
+TEST(RuntimeTest, UnmeasuredTrackedQubit) {
     const char* src = "function main() -> void { @tracked qubit q; }";
     auto program = parseProgram(src);
     SemanticAnalyser analyser;
@@ -170,7 +170,18 @@ TEST(RuntimeTest, UninitializedTrackedVariable) {
     RuntimeEvaluator eval;
     eval.execute(*program);
     const auto& counts = eval.trackedCounts();
-    ASSERT_EQ(counts.at("qubit q").at("0"), 1);
+    ASSERT_EQ(counts.at("qubit q").at("?"), 1);
+}
+
+TEST(RuntimeTest, MeasuredTrackedQubit) {
+    const char* src = "function main() -> void { @tracked qubit q; x(q); measure q; }";
+    auto program = parseProgram(src);
+    SemanticAnalyser analyser;
+    analyser.analyse(*program);
+    RuntimeEvaluator eval;
+    eval.execute(*program);
+    const auto& counts = eval.trackedCounts();
+    ASSERT_EQ(counts.at("qubit q").at("1"), 1);
 }
 
 TEST(RuntimeTest, ResetClearsQubit) {

--- a/tests/test_runtime.cpp
+++ b/tests/test_runtime.cpp
@@ -116,18 +116,18 @@ TEST(RuntimeTest, PostIncrementAndDecrement) {
 }
 
 TEST(RuntimeTest, TracksVariableSingleShot) {
-    const char* src = "function main() -> void { @tracked int x = 1; }";
+    const char* src = "function main() -> void { @tracked qubit q; x(q); }";
     auto program = parseProgram(src);
     SemanticAnalyser analyser;
     analyser.analyse(*program);
     RuntimeEvaluator eval;
     eval.execute(*program);
     const auto& counts = eval.trackedCounts();
-    ASSERT_EQ(counts.at("x").at("1"), 1);
+    ASSERT_EQ(counts.at("qubit q").at("?"), 1);
 }
 
 TEST(RuntimeTest, TracksVariableMultipleShots) {
-    const char* src = "function main() -> void { @tracked int x = 1; }";
+    const char* src = "function main() -> void { @tracked qubit q; x(q); }";
     auto program = parseProgram(src);
     SemanticAnalyser analyser;
     analyser.analyse(*program);
@@ -138,7 +138,7 @@ TEST(RuntimeTest, TracksVariableMultipleShots) {
         for (const auto& vk : eval.trackedCounts())
             for (const auto& vv : vk.second) agg[vk.first][vv.first] += vv.second;
     }
-    ASSERT_EQ(agg["x"]["1"], 5);
+    ASSERT_EQ(agg["qubit q"]["?"], 5);
 }
 
 TEST(RuntimeTest, EchoModes) {
@@ -163,14 +163,14 @@ TEST(RuntimeTest, EchoModes) {
 }
 
 TEST(RuntimeTest, UninitializedTrackedVariable) {
-    const char* src = "function main() -> void { @tracked int x; }";
+    const char* src = "function main() -> void { @tracked qubit q; }";
     auto program = parseProgram(src);
     SemanticAnalyser analyser;
     analyser.analyse(*program);
     RuntimeEvaluator eval;
     eval.execute(*program);
     const auto& counts = eval.trackedCounts();
-    ASSERT_EQ(counts.at("x").at("__unassigned__"), 1);
+    ASSERT_EQ(counts.at("qubit q").at("0"), 1);
 }
 
 TEST(RuntimeTest, ResetClearsQubit) {


### PR DESCRIPTION
Refactored `@tracked` CLI output and restricted it to qubit and qubit[] types only

closes #123 