### PR TITLE
ci: add new gh actions for e2e release flow (#140)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,7 @@ PR titles follow the same format as commits so that automation can pick up the i
    - Normal work → base `develop`
    - Release hardening fixes → base `release-vX.Y.Z`
 4. Fill in the PR template and ensure it references the issue the PR closes.
+5. Merge via **squash-and-merge** so a single Conventional Commit summarises the change for release automation.
 
 ### Automated checks on every PR
 - **PR Quality (`.github/workflows/pr-checks.yaml`)**
@@ -107,7 +108,7 @@ Our CI/CD pipeline automates the full release process end-to-end:
    - Merge the PR and tag `master` with `vX.Y.Z`.
    - The `Publish Release` workflow runs on that tag: it rebuilds artifacts for Linux/macOS, generates checksums, extracts release notes from the changelog, and publishes the GitHub release with assets attached.
 
-All automation runs from the repository’s default tokens; no manual changelog edits are needed because release-please owns `CHANGELOG.md`.
+All automation runs from the repository’s default tokens; no manual changelog edits are needed because release-please owns `CHANGELOG.md`. Merge PRs with **squash merge** so the release bot sees a single Conventional Commit per change; the changelog is now generated from PR titles via GitHub release notes.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ bloch --version
 - Merges to `develop` wake the release-please bot, which maintains the changelog and raises a `chore: release X.Y.Z` PR.
 - Merging that PR automatically creates `release-vX.Y.Z`, tags `vX.Y.Z-rc.1`, and runs the release-candidate workflow to build binaries and publish a prerelease.
 - Release fixes target the release branch and run the same quality checks; a final PR into `master` runs release dry runs, and tagging `vX.Y.Z` publishes production artifacts via GitHub Releases.
+- Use squash merges so each PR contributes a single Conventional Commit; Release Please now builds changelog entries from merged PR titles.
 
 ## Contributing
 Bloch is an open-source project and we welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for contribution guidelines and local build instructions.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,6 +14,7 @@
     ".": {
       "component": "bloch",
       "release-type": "simple",
+      "changelog-type": "github",
       "changelog-path": "CHANGELOG.md",
       "include-component-in-tag": false,
       "initial-version": "1.0.0"


### PR DESCRIPTION
Changed changelog-type for release-please to github. Added documentation to say that merges to develop should be squash merged